### PR TITLE
Fixes Off-By-One in Json and Adds Windows Build Instructions to Readme

### DIFF
--- a/com_osvr_Nolo.json
+++ b/com_osvr_Nolo.json
@@ -80,17 +80,17 @@
       },
       "right": {
         "$target": "tracker/3",
-        "system": "button/10",
-        "menu": "button/9",
-        "grip": "button/11",
+        "system": "button/9",
+        "menu": "button/8",
+        "grip": "button/10",
         "trackpad": {
           "x": "analog/3",
           "y": "analog/4",
-          "touch": "button/12",
-          "button": "button/7"
+          "touch": "button/11",
+          "button": "button/6"
         },
         "trigger": {
-          "button": "button/8"
+          "button": "button/7"
         },
         "battery": "analog/5"
       }

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,10 @@ Open the CMAKE gui and point the source line at top to your checked out repo. Po
 
 Press `Add Entry` and input `CMAKE_PREFIX_PATH` as the name. Set the Type to path, and in the Value field include the paths to the OSVR SDK and the NoloVR SDK. This *should* be all you need, but you might need to include additional paths (after downloading their respective libraries) if you get an error asking for libfunctionality or Boost. Look through OSVR-Core documentation for instructions on these.
 
+If you encounter strange, nearly silent build errors, it may be that OSVR-Core was detected in the wrong directory by CMAKE. 
+
+The easiest way to fix this is to check the osvr_DIR entry in CMAKE and ensure it is set to an installation of the SDK binaries downloaded from https://osvr.github.io/using/.
+
 Press `Configure`.
 
 You will get an error that says HIDAPI cannot be found. This is expected. If you get any other errors, see the above comment about adding paths to Boost etc.

--- a/readme.md
+++ b/readme.md
@@ -63,25 +63,23 @@ Now build `hidapi` (from the Build menu in the toolbar or by right-clicking `hid
 
 Open the CMAKE gui and point the source line at top to your checked out repo. Point the build directory where you want the VS project files to go.
 
-Press `Add Entry` and input `CMAKE_PREFIX_PATH` as the name. Set the Type to path, and in the Value field include the paths to the OSVR SDK and the NoloVR SDK. This *should* be all you need, but you might need to include additional paths (after downloading their respective libraries) if you get an error asking for libfunctionality or Boost. Look through OSVR-Core documentation for instructions on these.
-
-If you encounter strange, nearly silent build errors, it may be that OSVR-Core was detected in the wrong directory by CMAKE. 
-
-The easiest way to fix this is to check the osvr_DIR entry in CMAKE and ensure it is set to an installation of the SDK binaries downloaded from https://osvr.github.io/using/.
-
 Press `Configure`.
 
-You will get an error that says HIDAPI cannot be found. This is expected. If you get any other errors, see the above comment about adding paths to Boost etc.
+You may get errors that say certain dependencies cannot be found. If CMAKE can't find them automatically, here's a list of where to point them to as they appear:
 
-To resolve the HIDAPI error, select the `HIDAPI_INCLUDE_DIR` entry and point it to `your-hidapi-dir\hidapi\`, the foldering containing `hidapi.h`
+Key | Directory
+------------ | -------------
+osvr_DIR | Find your OSVR SDK, then point to x64\lib\cmake\osvr
+libfunctionality_DIR | Find your OSVR SDK, then point to x64\lib\cmake\libfunctionality
+HIDAPI_INCLUDE_DIR | Find your HIDAPI install directory, then point to the hidapi subfolder (contains hidapi.h)
+HIDAPI_LIBRARY | Find your HIDAPI install directory, then point to windows\x64\Release\hidapi.lib
 
-Then select the `HIDAPI_LIBRARY` entry and point it to `hidapi.lib` in `your-hidapi-dir\Windows\x64\Release`
-
-This error seems to be the result of an issue with a CMAKE file, but I can't seem to fix it. Perhaps an expert can submit a PR.
 
 Press `Configure` again. Hopefully all errors are gone. Press `Generate` then `Open Project`
 
-Build as you normally would in VS. Remember if Releasing to right-click the `INSTALL` project, select properties, open Configuration Manager, and change active solution configuration to `Release` or `RelWithDebInfo`.
+Build as you normally would in VS. Remember if Releasing to right-click the `INSTALL` project, select properties, open Configuration Manager, and change active solution configuration to `RelWithDebInfo`.
+
+**DO NOT RELEASE WITH THE CONFIGURATION SET TO "RELEASE"**. For some reason, it most versions of VS this will cause the plugin to silently fail to load, even though it will build correctly.
 
 # Installation
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # About 
-nolo-vr is an OSVR plugin for LYRobotix Nolo VR tracker system.
+nolo-osvr is an OSVR plugin for LYRobotix Nolo VR tracker system.
 
 # Requirements
 * [OSVR Core](https://github.com/OSVR/OSVR-Core) - The core libraries for the OSVR software.
@@ -79,7 +79,7 @@ Press `Configure` again. Hopefully all errors are gone. Press `Generate` then `O
 
 Build as you normally would in VS. Remember if Releasing to right-click the `INSTALL` project, select properties, open Configuration Manager, and change active solution configuration to `RelWithDebInfo`.
 
-**DO NOT RELEASE WITH THE CONFIGURATION SET TO "RELEASE"**. For some reason, it most versions of VS this will cause the plugin to silently fail to load, even though it will build correctly.
+**DO NOT BUILD WITH THE CONFIGURATION SET TO "RELEASE"**. For some reason, it most versions of VS this will cause the plugin to silently fail to load, even though it will build correctly.
 
 # Installation
 
@@ -91,5 +91,5 @@ To-do
 
 Copy `hidapi.dll` from `your-hidapi-directory\windows\x64\Release` into `your-OSVR-Core-directory\bin`
 
-Copy `com_osvr_Nolo.dll` into your-OSVR-Core-director\bin\osvr-plugins-0`
+Copy `com_osvr_Nolo.dll` into `your-OSVR-Core-director\bin\osvr-plugins-0`
 

--- a/readme.md
+++ b/readme.md
@@ -11,13 +11,15 @@ The following are tools for creating an automated development environment:
 
 # Building
 
+## Linux
+
 Create a build directory.
 
 ```
 mkdir build
 ```
 
-## Compile
+### Compile
 The following command has a variable called INSTALL_DIR.  Change this to the location where the other OSVR components are installed.
 
 ```
@@ -25,12 +27,12 @@ cd build
 cmake ..  -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
 ```
 
-# Setup
+### Setup
 Run the following:
 
 ``` make install ```
 
-## udev rules
+### udev rules
 The udev rules need to be added to /etc/udev/rules.d
 
 ``` sudo cp 99-nolo.rules /etc/udev/rules.d/.  ```
@@ -39,6 +41,53 @@ Run the following command to update udev.
 
 ``` sudo udevadm trigger ```
 
-## nolo configuration
+### nolo configuration
 
 TODO
+
+## Windows (with VS 2013 and CMAKE gui)
+
+### Build HIDAPI
+
+Clone [hidapi](https://github.com/signal11/hidapi) into a directory of choice. Then navigate to Windows and open hidapi.sln to open the project.
+
+Visual Studio will probably ask to update the project files due to VS version incompatibility - let it do so.
+
+In the Solution Explorer, right-click on `hidapi` and then select `Configuration Manager`. Change the `Active solution configuration` to Release, then change the `Active solution platform` to x64.
+
+If x64 is not an option, select the drop-down and select `<New`>. Choose x64 as the new platform and copy settings from Win32.
+
+Now build `hidapi` (from the Build menu in the toolbar or by right-clicking `hidapi` in the Solution Explorer).
+
+### Build Nolo-OSVR
+
+Open the CMAKE gui and point the source line at top to your checked out repo. Point the build directory where you want the VS project files to go.
+
+Press `Add Entry` and input `CMAKE_PREFIX_PATH` as the name. Set the Type to path, and in the Value field include the paths to the OSVR SDK and the NoloVR SDK. This *should* be all you need, but you might need to include additional paths (after downloading their respective libraries) if you get an error asking for libfunctionality or Boost. Look through OSVR-Core documentation for instructions on these.
+
+Press `Configure`.
+
+You will get an error that says HIDAPI cannot be found. This is expected. If you get any other errors, see the above comment about adding paths to Boost etc.
+
+To resolve the HIDAPI error, select the `HIDAPI_INCLUDE_DIR` entry and point it to `your-hidapi-dir\hidapi\`, the foldering containing `hidapi.h`
+
+Then select the `HIDAPI_LIBRARY` entry and point it to `hidapi.lib` in `your-hidapi-dir\Windows\x64\Release`
+
+This error seems to be the result of an issue with a CMAKE file, but I can't seem to fix it. Perhaps an expert can submit a PR.
+
+Press `Configure` again. Hopefully all errors are gone. Press `Generate` then `Open Project`
+
+Build as you normally would in VS. Remember if Releasing to right-click the `INSTALL` project, select properties, open Configuration Manager, and change active solution configuration to `Release` or `RelWithDebInfo`.
+
+# Installation
+
+## Linux
+
+To-do
+
+## Windows
+
+Copy `hidapi.dll` from `your-hidapi-directory\windows\x64\Release` into `your-OSVR-Core-directory\bin`
+
+Copy `com_osvr_Nolo.dll` into your-OSVR-Core-director\bin\osvr-plugins-0`
+


### PR DESCRIPTION
First and foremost, I apologize for not separating these into two branches.

This PR fixes #11, the off-by-one error in com_osvr_Nolo.json that was causing right-hand controller buttons to register incorrectly (e.g. the "menu" button was seen at the "grip" semantic path.)

It also closes #12 by including (hopefully) extensive instructions in readme.md for building on Windows.